### PR TITLE
Corrected typo for `json2csv` command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
 	{
 		"caption": "Json2Csv: Convert JSON to CSV",
-		"command": "json2cs"
+		"command": "json2csv"
 	}
 ]


### PR DESCRIPTION
I was trying out your plugin and noticed the command was missing from my command palette. It looks like you had a typo which I have corrected.
